### PR TITLE
Add a force-all flag that force re-gen all infomation

### DIFF
--- a/src/dantalian/mod.rs
+++ b/src/dantalian/mod.rs
@@ -17,14 +17,14 @@ mod data;
 mod job;
 mod utils;
 
-pub async fn dantalian(source: &Path, forces: &HashSet<String>) -> Result<()> {
+pub async fn dantalian(source: &Path, forces: &HashSet<String>, force_all: bool) -> Result<()> {
     info!("Run dantalian for {}", source.to_string_lossy());
     for e in WalkDir::new(source).min_depth(1).max_depth(1) {
         let entry = e?;
         if entry.file_type().is_dir() {
             let path = path_str(entry.path())?;
             info!(ind: 1, "Check {} ...", path);
-            match handle_dir(entry.path(), forces.contains(path)).await {
+            match handle_dir(entry.path(), force_all || forces.contains(path)).await {
                 Ok(_) => info!(ind: 2, "Completed!"),
                 Err(e) => error!(ind: 2, "Failed: {}", e),
             };

--- a/src/dantalian/utils.rs
+++ b/src/dantalian/utils.rs
@@ -1,13 +1,8 @@
-use anyhow::{anyhow, Result};
 use once_cell::sync::Lazy;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::Path;
 use std::sync::Mutex;
-
-pub fn path_str(path: &Path) -> Result<&str> {
-    path.to_str().ok_or_else(|| anyhow!("path is not valid"))
-}
 
 // VIDEO_EXTS is collected from: https://en.wikipedia.org/wiki/Video_file_format
 static VIDEO_EXTS: Lazy<Mutex<HashSet<&'static str>>> = Lazy::new(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
                 if force.contains(&path) {
                     return true;
                 }
-                return false;
+                false
             };
             for source in opts.source {
                 dantalian(&source, is_force).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,15 +21,7 @@ async fn main() -> Result<()> {
         None => {
             let force: HashSet<String> = HashSet::from_iter(opts.force);
             let force_all = opts.force_all;
-            let is_force = |path| {
-                if force_all {
-                    return true;
-                }
-                if force.contains(&path) {
-                    return true;
-                }
-                false
-            };
+            let is_force = |path| force_all || force.contains(&path);
             for source in opts.source {
                 dantalian(&source, is_force).await?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
                 force.insert(f);
             }
             for source in opts.source {
-                dantalian(&source, &force).await?;
+                dantalian(&source, &force, opts.force_all).await?;
             }
             Ok(())
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use dantalian::{info, logger::Logger};
 use log::set_logger;
 use options::{BgmCmd, BgmSubCmd, Opts, SubCmd};
 use std::collections::HashSet;
+use std::iter::FromIterator;
 
 mod options;
 
@@ -18,12 +19,19 @@ async fn main() -> Result<()> {
     }
     match opts.subcmd {
         None => {
-            let mut force: HashSet<String> = HashSet::new();
-            for f in opts.force {
-                force.insert(f);
-            }
+            let force: HashSet<String> = HashSet::from_iter(opts.force);
+            let force_all = opts.force_all;
+            let is_force = |path| {
+                if force_all {
+                    return true;
+                }
+                if force.contains(&path) {
+                    return true;
+                }
+                return false;
+            };
             for source in opts.source {
-                dantalian(&source, &force, opts.force_all).await?;
+                dantalian(&source, is_force).await?;
             }
             Ok(())
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -14,6 +14,8 @@ pub struct Opts {
         required = false
     )]
     pub force: Vec<String>,
+    #[clap(long, about = "force re-generate all anime")]
+    pub force_all: bool,
     #[clap(subcommand)]
     pub subcmd: Option<SubCmd>,
 }


### PR DESCRIPTION
Add a new flag to options that force re-generate all nfo files.

![image](https://user-images.githubusercontent.com/9823531/125590730-2c8eed66-203b-4523-8dab-636bfd20c528.png)
