### PR TITLE
fix generate failed for movie with empty name

### DIFF
--- a/src/dantalian/data.rs
+++ b/src/dantalian/data.rs
@@ -83,6 +83,7 @@ impl From<BgmAnime> for AnimeData {
         }
         let rc_directors = Rc::from(directors);
         let rc_credits = Rc::from(credits);
+        let episode_len = episodes.len();
 
         for be in episodes {
             if !be.is_empty() {
@@ -106,7 +107,28 @@ impl From<BgmAnime> for AnimeData {
                     aired: Some(be.airdate),
                     studio: None,
                     actors: Rc::clone(&data.tvshow.actors),
-                })
+                });
+            } else if episode_len == 1 && be.episode_type == EpisodeType::Honpen && be.ep == Some(1)
+            {
+                data.episodes.push(Episode {
+                    uid: be.id,
+                    title: data.tvshow.title.clone(),
+                    original_title: data.tvshow.original_title.clone(),
+                    show_title: String::from(&data.tvshow.title),
+                    rating_value: None,
+                    rating_votes: None,
+                    ep_index: format!("{}", be.sort),
+                    is_sp: false,
+                    plot: be.desc,
+                    directors: Rc::clone(&rc_directors),
+                    credits: Rc::clone(&rc_credits),
+                    premiered: String::from(&data.tvshow.premiered),
+                    // New bangumi api has no status.
+                    status: None,
+                    aired: Some(be.airdate),
+                    studio: None,
+                    actors: Rc::clone(&data.tvshow.actors),
+                });
             }
         }
         data


### PR DESCRIPTION
> get_subject_info: 294135
url = https://api.bgm.tv/v0/episodes?subject_id=294135
status: 200 OK
subject ep: Episode {
    id: 1029204,
    episode_type: Honpen,
    ep: Some(
        1,
    ),
    sort: 1.0,
    name: "",
    name_cn: "",
    duration: "",
    airdate: "",
    comment: 49,
    desc: "",
    duration_seconds: Some(
        0,
    ),
}
      Fetch anime data for: [294135] 劇場版 少女☆歌劇 レヴュースタァライト / 剧场版 少女☆歌剧 Revue Starlight
        Generate Eiga/[2021 Movie][Shoujo Kageki Revue Starlight The Movie][BDRIP][1080P+SP]/[Shoujo Kageki Revue Starlight The Movie][01][BDRIP][1920x804][H264_FLAC].nfo ...
    Failed: Can't find ep 1, is_sp false
Can't find ep 1, is_sp false

If the episode with empty name and name_cn, the generator will skip this episode. This leads to some incorrect generation for some movies with one episode.